### PR TITLE
extended the noshow report to display more information

### DIFF
--- a/hotel/site_sections/hotel.py
+++ b/hotel/site_sections/hotel.py
@@ -38,9 +38,8 @@ class Root:
         return {'staffers': staffers}
 
     def no_shows(self, session):
-        staffers = session.query(Attendee).filter_by(badge_type=c.STAFF_BADGE).order_by(Attendee.full_name).all()
-        staffers = [s for s in staffers if s.hotel_nights and not s.checked_in]
-        return {'staffers': staffers}
+        staffers = [ra.attendee for ra in session.query(RoomAssignment).all() if not ra.attendee.checked_in]
+        return {'staffers': sorted(staffers, key=lambda a: a.full_name)}
 
     @ajax
     def approve(self, session, id, approved):

--- a/hotel/templates/hotel/no_shows.html
+++ b/hotel/templates/hotel/no_shows.html
@@ -4,19 +4,36 @@
 
 <h2> {{ staffers|length }} Staffers With Hotel Space Who Have Not Checked In </h2>
 
-<table class="list">
-<tr class="header">
-    <td> Staffer Name </td>
-    <td> Departments </td>
-    <td> Room Nights </td>
-</tr>
+Note that occasionally someone will mistakenly get a badge and not be marked as checked in.  For this reason, this report
+also shows their worked hours.
+
+<br/> <br/>
+
+<table style="width:100%">
+<thead style="font-weight:bold">
+    <tr>
+        <td> Staffer Name </td>
+        <td> Departments </td>
+        <td> Worked Hours </td>
+        <td> Requested Nights </td>
+        <td> Assigned Room Nights </td>
+    </tr>
+</thead>
+<tbody>
 {% for attendee in staffers %}
     <tr>
         <td> {{ attendee|form_link }} </td>
         <td> {{ attendee.assigned_depts_labels|join:" / " }} </td>
+        <td> {{ attendee.worked_hours }} ({{ attendee.nonshift_hours }} nonshift) </td>
         <td> {{ attendee.hotel_requests.nights_display }} </td>
+        <td>
+            {% for ra in attendee.room_assignments %}
+                <div>{{ ra.room.nights_display }}</div>
+            {% endfor %}
+        </td>
     </tr>
 {% endfor %}
+</tbody>
 </table>
 
 {% endblock %}


### PR DESCRIPTION
The report of staffers who have been given hotel space but have not yet checked in has been extended in the following ways:
- it now draws from the list of actual room assignments rather than from hotel requests
- it now shows both requested and actual room nights
- it now shows the worked hours, since staffers occasionally show up without checking in
