### PR TITLE
Update automated_emails.py

### DIFF
--- a/hotel/automated_emails.py
+++ b/hotel/automated_emails.py
@@ -2,20 +2,20 @@ from hotel import *
 
 AutomatedEmail.extra_models[Room] = lambda session: session.query(Room).all()
 
-AutomatedEmail('Want volunteer hotel room space at {EVENT_NAME}?', 'hotel_rooms.txt',
-           lambda a: days_before(45, c.ROOM_DEADLINE, 14) and c.AFTER_SHIFTS_CREATED and a.hotel_eligible, sender='MAGFest Staff Rooms <staffrooms@magfest.org>')
+AutomatedEmail(Attendee, 'Want volunteer hotel room space at {EVENT_NAME}?', 'hotel_rooms.txt',
+           lambda a: days_before(45, c.ROOM_DEADLINE, 14) and c.AFTER_SHIFTS_CREATED and a.hotel_eligible, sender=c.ROOM_EMAIL_SENDER)
 
-AutomatedEmail('Reminder to sign up for {EVENT_NAME} hotel room space', 'hotel_reminder.txt',
-           lambda a: days_before(14, c.ROOM_DEADLINE, 2) and a.hotel_eligible and not a.hotel_requests, sender='MAGFest Staff Rooms <staffrooms@magfest.org>')
+AutomatedEmail(Attendee, 'Reminder to sign up for {EVENT_NAME} hotel room space', 'hotel_reminder.txt',
+           lambda a: days_before(14, c.ROOM_DEADLINE, 2) and a.hotel_eligible and not a.hotel_requests, sender=c.ROOM_EMAIL_SENDER)
 
-AutomatedEmail('Last chance to sign up for {EVENT_NAME} hotel room space', 'hotel_reminder.txt',
-           lambda a: days_before(2, c.ROOM_DEADLINE) and a.hotel_eligible and not a.hotel_requests, sender='MAGFest Staff Rooms <staffrooms@magfest.org>')
+AutomatedEmail(Attendee, 'Last chance to sign up for {EVENT_NAME} hotel room space', 'hotel_reminder.txt',
+           lambda a: days_before(2, c.ROOM_DEADLINE) and a.hotel_eligible and not a.hotel_requests, sender=c.ROOM_EMAIL_SENDER)
 
-AutomatedEmail('Reminder to meet your {EVENT_NAME} hotel room requirements', 'hotel_hours.txt',
-           lambda a: days_before(14, c.UBER_TAKEDOWN, 7) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender='MAGFest Staff Rooms <staffrooms@magfest.org>')
+AutomatedEmail(Attendee, 'Reminder to meet your {EVENT_NAME} hotel room requirements', 'hotel_hours.txt',
+           lambda a: days_before(14, c.UBER_TAKEDOWN, 7) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender=c.ROOM_EMAIL_SENDER)
 
-AutomatedEmail('Final reminder to meet your {EVENT_NAME} hotel room requirements', 'hotel_hours.txt',
-           lambda a: days_before(7, c.UBER_TAKEDOWN) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender='MAGFest Staff Rooms <staffrooms@magfest.org>')
+AutomatedEmail(Attendee, 'Final reminder to meet your {EVENT_NAME} hotel room requirements', 'hotel_hours.txt',
+           lambda a: days_before(7, c.UBER_TAKEDOWN) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender=c.ROOM_EMAIL_SENDER)
 
 AutomatedEmail(Room, '{EVENT_NAME} Hotel Room Assignment', 'room_assignment.txt', lambda r: r.locked_in,
-               sender=c.ROOM_EMAIL_SENDER, sender='MAGFest Staff Rooms <staffrooms@magfest.org>')
+               sender=c.ROOM_EMAIL_SENDER)

--- a/hotel/automated_emails.py
+++ b/hotel/automated_emails.py
@@ -2,22 +2,20 @@ from hotel import *
 
 AutomatedEmail.extra_models[Room] = lambda session: session.query(Room).all()
 
+AutomatedEmail('Want volunteer hotel room space at {EVENT_NAME}?', 'hotel_rooms.txt',
+           lambda a: days_before(45, c.ROOM_DEADLINE, 14) and c.AFTER_SHIFTS_CREATED and a.hotel_eligible, sender='MAGFest Staff Rooms <staffrooms@magfest.org>')
 
-StopsEmail('Want volunteer hotel room space at {EVENT_NAME}?', 'hotel_rooms.txt',
-           lambda a: days_before(45, c.ROOM_DEADLINE, 14) and c.AFTER_SHIFTS_CREATED and a.hotel_eligible)
+AutomatedEmail('Reminder to sign up for {EVENT_NAME} hotel room space', 'hotel_reminder.txt',
+           lambda a: days_before(14, c.ROOM_DEADLINE, 2) and a.hotel_eligible and not a.hotel_requests, sender='MAGFest Staff Rooms <staffrooms@magfest.org>')
 
-StopsEmail('Reminder to sign up for {EVENT_NAME} hotel room space', 'hotel_reminder.txt',
-           lambda a: days_before(14, c.ROOM_DEADLINE, 2) and a.hotel_eligible and not a.hotel_requests)
+AutomatedEmail('Last chance to sign up for {EVENT_NAME} hotel room space', 'hotel_reminder.txt',
+           lambda a: days_before(2, c.ROOM_DEADLINE) and a.hotel_eligible and not a.hotel_requests, sender='MAGFest Staff Rooms <staffrooms@magfest.org>')
 
-StopsEmail('Last chance to sign up for {EVENT_NAME} hotel room space', 'hotel_reminder.txt',
-           lambda a: days_before(2, c.ROOM_DEADLINE) and a.hotel_eligible and not a.hotel_requests)
+AutomatedEmail('Reminder to meet your {EVENT_NAME} hotel room requirements', 'hotel_hours.txt',
+           lambda a: days_before(14, c.UBER_TAKEDOWN, 7) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender='MAGFest Staff Rooms <staffrooms@magfest.org>')
 
-StopsEmail('Reminder to meet your {EVENT_NAME} hotel room requirements', 'hotel_hours.txt',
-           lambda a: days_before(14, c.UBER_TAKEDOWN, 7) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS)
-
-StopsEmail('Final reminder to meet your {EVENT_NAME} hotel room requirements', 'hotel_hours.txt',
-           lambda a: days_before(7, c.UBER_TAKEDOWN) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS)
-
+AutomatedEmail('Final reminder to meet your {EVENT_NAME} hotel room requirements', 'hotel_hours.txt',
+           lambda a: days_before(7, c.UBER_TAKEDOWN) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender='MAGFest Staff Rooms <staffrooms@magfest.org>')
 
 AutomatedEmail(Room, '{EVENT_NAME} Hotel Room Assignment', 'room_assignment.txt', lambda r: r.locked_in,
-               sender=c.ROOM_EMAIL_SENDER)
+               sender=c.ROOM_EMAIL_SENDER, sender='MAGFest Staff Rooms <staffrooms@magfest.org>')


### PR DESCRIPTION
This should update all Staff Room Emails to come from 'MAGFest Staff Rooms staffrooms@magfest.org instead of stops@magfest.org - We are the same department, but for sorting/issue tracking it has become easier to break this away from the general Staff Operations questions.
