### PR TITLE
Update configspec.ini

### DIFF
--- a/hotel/configspec.ini
+++ b/hotel/configspec.ini
@@ -3,7 +3,7 @@
 # [dates] section of the main repo's config when including this plugin.
 
 # Email address which will be the sender for the hotel room emails.
-ROOM_EMAIL_SENDER = string(default='staffrooms@magfest.org')
+ROOM_EMAIL_SENDER = string(default='MAGFest Staff Rooms <staffrooms@magfest.org>')
 
 # In some of our pages and emails relating to hotel room nights, it makes sense
 # to list the nights in order based on the start of the event rather than the


### PR DESCRIPTION
This should change the Room_Email_sender from just the email address of staffrooms@magfest.org to:
'MAGFest Staff Rooms staffrooms@magfest.org' So there is a Department name displayed at:
https://prime.uber.magfest.org/uber/emails/pending and when the emails go out.
