### PR TITLE
Update configspec.ini

### DIFF
--- a/hotel/configspec.ini
+++ b/hotel/configspec.ini
@@ -8,7 +8,7 @@ ROOM_EMAIL_SENDER = string(default='MAGFest Staff Rooms <staffrooms@magfest.org>
 # In some of our pages and emails relating to hotel room nights, it makes sense
 # to list the nights in order based on the start of the event rather than the
 # first day of the week.
-night_display_order = string_list(default=list("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"))
+night_display_order = string_list(default=list("tuesday", "wednesday", "thursday", "friday", "saturday", "sunday","monday"))
 
 # When people are able to pick up their room keys from the hotel front desk.
 check_in_time = string(default='4pm')
@@ -18,4 +18,4 @@ check_out_time = string(default='10am')
 
 # How many hours are required before a volunteer is eligible for hotel space.
 # This often will be different based on the length of the event.
-hotel_req_hours = integer(default='24')
+hotel_req_hours = integer(default='30')


### PR DESCRIPTION
Changed day display order to be Tues-Monday. We might have a 2 or 3 rooms the monday before events, but we can add those in manually, we will have more people staying Monday night after the event.

Also updated hours to 30 instead of 24 for MAGFest.
