### PR TITLE
fix hotel requests not cascading attendee data save on save

### DIFF
--- a/hotel/models.py
+++ b/hotel/models.py
@@ -101,11 +101,9 @@ class HotelRequests(MagModel, NightsMixin):
     special_needs      = Column(UnicodeText)
     approved           = Column(Boolean, default=False, admin_only=True)
 
-    def approve(self):
-        self.approved = True
-
     def decline(self):
         self.nights = ','.join(night for night in self.nights.split(',') if int(night) in c.CORE_NIGHTS)
+        # self.approved = False
 
     @presave_adjustment
     def cascading_save(self):

--- a/hotel/models.py
+++ b/hotel/models.py
@@ -103,7 +103,6 @@ class HotelRequests(MagModel, NightsMixin):
 
     def decline(self):
         self.nights = ','.join(night for night in self.nights.split(',') if int(night) in c.CORE_NIGHTS)
-        # self.approved = False
 
     @presave_adjustment
     def cascading_save(self):

--- a/hotel/models.py
+++ b/hotel/models.py
@@ -107,7 +107,6 @@ class HotelRequests(MagModel, NightsMixin):
     def decline(self):
         self.nights = ','.join(night for night in self.nights.split(',') if int(night) in c.CORE_NIGHTS)
 
-    # TODO: DOES NOT CURRENTLY GET CALLED, BROKEN, NEED TO FIX
     @presave_adjustment
     def cascading_save(self):
         self.attendee.presave_adjustments()

--- a/hotel/models.py
+++ b/hotel/models.py
@@ -101,8 +101,16 @@ class HotelRequests(MagModel, NightsMixin):
     special_needs      = Column(UnicodeText)
     approved           = Column(Boolean, default=False, admin_only=True)
 
+    def approve(self):
+        self.approved = True
+
     def decline(self):
         self.nights = ','.join(night for night in self.nights.split(',') if int(night) in c.CORE_NIGHTS)
+
+    # TODO: DOES NOT CURRENTLY GET CALLED, BROKEN, NEED TO FIX
+    @presave_adjustment
+    def cascading_save(self):
+        self.attendee.presave_adjustments()
 
     def __repr__(self):
         return '<{self.attendee.full_name} Hotel Requests>'.format(self=self)

--- a/hotel/site_sections/hotel.py
+++ b/hotel/site_sections/hotel.py
@@ -45,7 +45,7 @@ class Root:
     def approve(self, session, id, approved):
         hr = session.hotel_requests(id)
         if approved == 'approved':
-            hr.approve()
+            hr.approved = True
         else:
             hr.decline()
         session.commit()

--- a/hotel/site_sections/hotel.py
+++ b/hotel/site_sections/hotel.py
@@ -45,7 +45,7 @@ class Root:
     def approve(self, session, id, approved):
         hr = session.hotel_requests(id)
         if approved == 'approved':
-            hr.approved = True
+            hr.approve()
         else:
             hr.decline()
         session.commit()

--- a/hotel/tests/test_attendee_properties.py
+++ b/hotel/tests/test_attendee_properties.py
@@ -23,3 +23,23 @@ def test_hotel_shifts_required_preshifts(monkeypatch):
     monkeypatch.setattr(Attendee, 'takes_shifts', True)
     monkeypatch.setattr(Attendee, 'hotel_nights', [c.THURSDAY, c.FRIDAY])
     assert not Attendee().hotel_shifts_required
+
+
+def test_hotel_request_allows_setup_and_teardown(monkeypatch):
+    with Session() as session:
+        attendee = Attendee()
+        session.add(attendee)
+        session.commit()
+        assert not attendee.can_work_setup
+        assert not attendee.can_work_teardown
+
+        hr = HotelRequests()
+        hr.attendee = attendee
+        session.add(hr)
+        hr.nights = ','.join(map(str, [c.WEDNESDAY, c.THURSDAY, c.MONDAY]))
+
+        attendee.hotel_requests.approve()
+        session.commit()
+
+        assert attendee.can_work_setup
+        assert attendee.can_work_teardown

--- a/hotel/tests/test_attendee_properties.py
+++ b/hotel/tests/test_attendee_properties.py
@@ -25,25 +25,45 @@ def test_hotel_shifts_required_preshifts(monkeypatch):
     assert not Attendee().hotel_shifts_required
 
 
-def test_by_default_no_setup_and_teardown(monkeypatch):
-    with Session() as session:
+class TestHotelRequests:
+
+    @pytest.fixture(autouse=True)
+    def hotel_request_unapproved_setup_teardown(self):
+        # create an Attendee and HotelRequest for nights before and after the event, but don't approve the request yet
+        hr = HotelRequests()
+        hr.nights = ','.join(map(str, [c.WEDNESDAY, c.THURSDAY, c.MONDAY]))
+        hr.attendee = Attendee()
+        hr.presave_adjustments()
+        return hr
+
+    @pytest.fixture(autouse=True)
+    def hotel_request_and_approve_setup_teardown(self, hotel_request_unapproved_setup_teardown):
+        # create an Attendee and HotelRequest for nights before and after the event, and approve the request.
+        hotel_request_unapproved_setup_teardown.approved = True
+        hotel_request_unapproved_setup_teardown.presave_adjustments()
+        return hotel_request_unapproved_setup_teardown
+
+    def test_by_default_no_setup_and_teardown(self):
         attendee = Attendee()
         attendee.presave_adjustments()
         assert not attendee.can_work_setup
         assert not attendee.can_work_teardown
 
+    def test_decline_setup_and_teardown(self, hotel_request_and_approve_setup_teardown):
+        """
+        if someone has previously been approved for their setup/teardown hotel request,
+        then later declines it, we still allow them to sign up for setup/teardown shifts
+        "If someone ends up being approved for setup nights and then declines their hotel space, it might just mean
+        that they decided to room with a friend or something. Allowing them to still take setup shifts seems
+        reasonable in that case." see https://github.com/magfest/hotel/issues/18
+        """
+        assert hotel_request_and_approve_setup_teardown.attendee.can_work_setup
+        assert hotel_request_and_approve_setup_teardown.attendee.can_work_teardown
 
-def test_hotel_approved_and_can_work_setup_and_teardown(monkeypatch):
-    with Session() as session:
-        hr = HotelRequests()
-        attendee = Attendee()
+        hotel_request_and_approve_setup_teardown.decline()
+        assert hotel_request_and_approve_setup_teardown.attendee.can_work_setup
+        assert hotel_request_and_approve_setup_teardown.attendee.can_work_teardown
 
-        # attendee requests shoulder nights, and we approve it
-        hr.attendee = attendee
-        hr.nights = ','.join(map(str, [c.WEDNESDAY, c.THURSDAY, c.MONDAY]))
-        hr.approve()
-
-        # on the next save, the attendee should be able to work setup and teardown
-        hr.presave_adjustments()
-        assert attendee.can_work_setup
-        assert attendee.can_work_teardown
+    def test_hotel_approved_and_can_work_setup_and_teardown(self, hotel_request_and_approve_setup_teardown):
+        assert hotel_request_and_approve_setup_teardown.attendee.can_work_setup
+        assert hotel_request_and_approve_setup_teardown.attendee.can_work_teardown

--- a/hotel/tests/test_attendee_properties.py
+++ b/hotel/tests/test_attendee_properties.py
@@ -25,21 +25,25 @@ def test_hotel_shifts_required_preshifts(monkeypatch):
     assert not Attendee().hotel_shifts_required
 
 
-def test_hotel_request_allows_setup_and_teardown(monkeypatch):
+def test_by_default_no_setup_and_teardown(monkeypatch):
     with Session() as session:
         attendee = Attendee()
-        session.add(attendee)
-        session.commit()
+        attendee.presave_adjustments()
         assert not attendee.can_work_setup
         assert not attendee.can_work_teardown
 
+
+def test_hotel_approved_and_can_work_setup_and_teardown(monkeypatch):
+    with Session() as session:
         hr = HotelRequests()
+        attendee = Attendee()
+
+        # attendee requests shoulder nights, and we approve it
         hr.attendee = attendee
-        session.add(hr)
         hr.nights = ','.join(map(str, [c.WEDNESDAY, c.THURSDAY, c.MONDAY]))
+        hr.approve()
 
-        attendee.hotel_requests.approve()
-        session.commit()
-
+        # on the next save, the attendee should be able to work setup and teardown
+        hr.presave_adjustments()
         assert attendee.can_work_setup
         assert attendee.can_work_teardown


### PR DESCRIPTION
@EliAndrewC throwing this up here for initial review.  Check out the unit test.

The problem I'm having is that on `session.commit()` the `@presave_adjustment` isn't getting called on `HotelRequests`

down inside sqlalchemy, when flush() gets called inside commit(), the _presave_adjustment function is not present as a listener.

Here's what it looks like in the debugger when _presave_adjustment is called correctly:
![image](https://cloud.githubusercontent.com/assets/5413064/11453462/65db069e-95d9-11e5-9b7e-61ca6d1facdc.png)

And here's what it looks like with HotelRequests:
![image](https://cloud.githubusercontent.com/assets/5413064/11453469/806b7c46-95d9-11e5-96dc-6e73ca31cadf.png)

Interesting thing: all other cases where we're using `@presave_adjustment` is on mixins for the Attendee model (where I have verified, it is working).  We've never tried using it on other models, like HotelRequests.  I wonder if this is some kind of problem with `@presave_adjustment` when called from plugins that aren't using it in the context of a mixin.

So, this code may be fine as-is, and there's just a different bug we didn't notice before preventing presave adjustments from getting called. (or, something else is going on here)

Will dig into this more later today when I have some time.
