### PR TITLE
Update room_assignment.txt

### DIFF
--- a/hotel/templates/emails/room_assignment.txt
+++ b/hotel/templates/emails/room_assignment.txt
@@ -13,23 +13,15 @@ Here are the people assigned to this room, along with their contact information 
 {{ ra.attendee.hotel_requests.nights_display }}
 {% endfor %}
 
-If you are assigned to receive a room on a night before {{ c.CORE_NIGHT_NAMES|first }}, please make sure that you have signed up for
-a setup shift for each of those days earlier days.  Similarly if you are staying past {{ c.CORE_NIGHT_NAMES|last }} please sign up
-for a corresponding tear-down shift after {{ c.EVENT_NAME }}.  If you were expecting to work setup and/or teardown and there are no
-available shifts, please let us know.  You MUST sign up for setup and teardown shifts if you are working during setup and/or
-teardown.
+If you are assigned to receive a room on a night before {{ c.CORE_NIGHT_NAMES|first }}, please make sure that you have signed up for a setup shift for each of those days earlier days.  Similarly if you are staying past {{ c.CORE_NIGHT_NAMES|last }} please sign up for a corresponding tear-down shift after {{ c.EVENT_NAME }}.  If you were expecting to work setup and/or teardown and there are no available shifts, please let us know.  You MUST sign up for setup and teardown shifts if you are working during setup and/or teardown.
 
-We make every attempt to room staffers with those people that they requested.  We do our best to assign everyone to a room with at
-least one requested person, but this may not possible for everyone, and we may add staff to rooms that had an open slot.
+We make every attempt to room staffers with those people that they requested.  We do our best to assign everyone to a room with at least one requested person, but this may not possible for everyone, and we may add staff to rooms that had an open slot.
 
 (Code for greater than 5 entries) 
 If you room appears over booked, you may have people moving out of room on {{ c.CORE_NIGHT_NAMES|first }}, into
-other rooms. We use the less number of rooms possible during the setup portion of {{ c.EVENT_NAME }} so we don’t have to pay for
-empty rooms.
+other rooms. We use the less number of rooms possible during the setup portion of {{ c.EVENT_NAME }} so we don’t have to pay for empty rooms.
 (close code for <5)
 
-If there are any issues with your room at event, please come to Fest Ops and let someone in Staffing Operations know.  They will
-relay the information to the hotel liaison team as soon as possible.  We appreciate your hard work and we hope that you enjoy 
-{{ c.EVENT_NAME }}.
+If there are any issues with your room at event, please come to Fest Ops and let someone in Staffing Operations know.  They will relay the information to the hotel liaison team as soon as possible.  We appreciate your hard work and we hope that you enjoy {{ c.EVENT_NAME }}.
 
 {{ c.STOPS_EMAIL_SIGNATURE }}

--- a/hotel/templates/emails/room_assignment.txt
+++ b/hotel/templates/emails/room_assignment.txt
@@ -1,20 +1,39 @@
 {{ room.first_names|join_and }},
 
-This email to confirm your {{ c.EVENT_NAME }} hotel staff room assignments.  Your roommates are listed below, so please take a moment to look over the information.  We will assume that all rooms are ok if you don’t reply to this email by {{ c.ONE_WEEK_OR_TAKEDOWN|datetime }}.
+This email is to confirm your upcoming {{ c.EVENT_NAME }} hotel staff room assignments.  Your roommates are listed below, so please
+take a moment to look over the information.  We will assume that all rooms are ok if you don’t reply to this email by 
+{{ c.ONE_WEEK_OR_TAKEDOWN|datetime }}.
 
 You can check in at the hotel front desk starting at {{ c.CHECK_IN_TIME }} on {{ room.check_in_date|date:"l, M j" }}.
 
-Your check-out is at {{ c.CHECK_OUT_TIME }} on {{ room.check_out_date|date:"l, M j" }}.  You do not need to drop off your room keys at the front desk; all you need to do is simply vacate the room by that time.  If for any reason you need additional time to vacate the room, please call the hotel front desk to see if you can have additional time.  If the hotel provides additional time, then you need to comply with the time provided.  Do not expect that this will be provided.
+Your check-out is at {{ c.CHECK_OUT_TIME }} on {{ room.check_out_date|date:"l, M j" }}.  You do not need to drop off your room keys
+at the front desk; all you need to do is simply vacate the room by that time.  If for any reason you need additional time to vacate
+the room, please call the hotel front desk to see if you can have additional time.  If the hotel provides additional time, then you
+need to comply with the time provided.  Do not expect that this will be provided.
 
 Here are the people assigned to this room, along with their contact information and what nights they'll be using the room:
 {% for ra in room.assignments %}
--> {{ ra.attendee.full_name }} ({{ ra.attendee.email }}){% if ra.attendee.cellphone %} [{{ ra.attendee.cellphone }}]{% endif %}: {{ ra.attendee.hotel_requests.nights_display }}
+-> {{ ra.attendee.full_name }} ({{ ra.attendee.email }}){% if ra.attendee.cellphone %} [{{ ra.attendee.cellphone }}]{% endif %}: 
+{{ ra.attendee.hotel_requests.nights_display }}
 {% endfor %}
 
-If you are assigned to receive a room on a night before {{ c.CORE_NIGHT_NAMES|first }}, please make sure that you have signed up for a setup shift for each of those days earlier days.  Similarly if you are staying past {{ c.CORE_NIGHT_NAMES|last }} please sign up for a corresponding tear-down shift after {{ c.EVENT_NAME }}.  If you were expecting to work setup and/or teardown and there are no available shifts, please let us know.  You MUST sign up for setup and teardown shifts if you are working during setup and/or teardown.
+If you are assigned to receive a room on a night before {{ c.CORE_NIGHT_NAMES|first }}, please make sure that you have signed up for
+a setup shift for each of those days earlier days.  Similarly if you are staying past {{ c.CORE_NIGHT_NAMES|last }} please sign up
+for a corresponding tear-down shift after {{ c.EVENT_NAME }}.  If you were expecting to work setup and/or teardown and there are no
+available shifts, please let us know.  You MUST sign up for setup and teardown shifts if you are working during setup and/or
+teardown.
 
-We make every attempt to room staffers with those people that they requested.  We do our best to assign everyone to a room with at least one requested person, but this may not possible for everyone, and we may add staff to rooms that had an open slot.
+We make every attempt to room staffers with those people that they requested.  We do our best to assign everyone to a room with at
+least one requested person, but this may not possible for everyone, and we may add staff to rooms that had an open slot.
 
-If there are any issues with your room at event, please come to Fest Ops and let someone in Staffing Ops know.  They will relay the information to the hotel liaison team as soon as possible.  We appreciate your hard work and we hope that you enjoy {{ c.EVENT_NAME }}.
+(Code for greater than 5 entries) 
+If you room appears over booked, you may have people moving out of room on {{ c.CORE_NIGHT_NAMES|first }}, into
+other rooms. We use the less number of rooms possible during the setup portion of {{ c.EVENT_NAME }} so we don’t have to pay for
+empty rooms.
+(close code for <5)
+
+If there are any issues with your room at event, please come to Fest Ops and let someone in Staffing Operations know.  They will
+relay the information to the hotel liaison team as soon as possible.  We appreciate your hard work and we hope that you enjoy 
+{{ c.EVENT_NAME }}.
 
 {{ c.STOPS_EMAIL_SIGNATURE }}

--- a/hotel/templates/emails/room_assignment.txt
+++ b/hotel/templates/emails/room_assignment.txt
@@ -1,15 +1,11 @@
 {{ room.first_names|join_and }},
 
-This email is to confirm your upcoming {{ c.EVENT_NAME }} hotel staff room assignments.  Your roommates are listed below, so please
-take a moment to look over the information.  We will assume that all rooms are ok if you don’t reply to this email by 
+This email is to confirm your upcoming {{ c.EVENT_NAME }} hotel staff room assignments.  Your roommates are listed below, so please take a moment to look over the information.  We will assume that all rooms are ok if you don’t reply to this email by 
 {{ c.ONE_WEEK_OR_TAKEDOWN|datetime }}.
 
 You can check in at the hotel front desk starting at {{ c.CHECK_IN_TIME }} on {{ room.check_in_date|date:"l, M j" }}.
 
-Your check-out is at {{ c.CHECK_OUT_TIME }} on {{ room.check_out_date|date:"l, M j" }}.  You do not need to drop off your room keys
-at the front desk; all you need to do is simply vacate the room by that time.  If for any reason you need additional time to vacate
-the room, please call the hotel front desk to see if you can have additional time.  If the hotel provides additional time, then you
-need to comply with the time provided.  Do not expect that this will be provided.
+Your check-out is at {{ c.CHECK_OUT_TIME }} on {{ room.check_out_date|date:"l, M j" }}.  You do not need to drop off your room keys at the front desk; all you need to do is simply vacate the room by that time.  If for any reason you need additional time to vacate the room, please call the hotel front desk to see if you can have additional time.  If the hotel provides additional time, then you need to comply with the time provided.  Do not expect that this will be provided.
 
 Here are the people assigned to this room, along with their contact information and what nights they'll be using the room:
 {% for ra in room.assignments %}


### PR DESCRIPTION
Made some textual changes to the first few paragraphs.

I would also like to see us add the optional section if the room has more than 5 people in it.... that can sometime happen when we shuffle around staff pre-event.   We don't have a clean way to show people that on Load-in days they are in a certain room, then on Core_nights they are in a separate room.
