### PR TITLE
added room message field

### DIFF
--- a/hotel/models.py
+++ b/hotel/models.py
@@ -114,6 +114,7 @@ class HotelRequests(MagModel, NightsMixin):
 
 class Room(MagModel, NightsMixin):
     notes      = Column(UnicodeText)
+    message    = Column(UnicodeText)
     locked_in  = Column(Boolean, default=False)
     nights     = Column(MultiChoice(c.NIGHT_OPTS))
     created    = Column(UTCDateTime, server_default=utcnow())

--- a/hotel/site_sections/hotel_assignments.py
+++ b/hotel/site_sections/hotel_assignments.py
@@ -139,7 +139,7 @@ class Root:
                 writerow(a, a.hotel_requests)
 
     @csv_file
-    def hilton_mark_center(self, out, session):
+    def passkey(self, out, session):
         """spreadsheet in the format requested by the Hilton Mark Center"""
         out.writerow(['Last Name', 'First Name', 'Arrival', 'Departure', 'Room Type', 'Number of Adults', 'Credit Card Name', 'Credit Card Number', 'Credit Card Expiration', 'Last Name 2', 'First Name 2', 'Last Name 3', 'First Name 3', 'Last Name 4', 'First Name 4', 'comments'])
         for room in session.query(Room).order_by(Room.created).all():
@@ -176,6 +176,7 @@ def _room_dict(room):
     return dict({
         'id': room.id,
         'notes': room.notes,
+        'message': room.message,
         'locked_in': room.locked_in,
         'nights': room.nights_display,
         'attendees': [_attendee_dict(ra.attendee) for ra in sorted(room.assignments, key=lambda ra: ra.attendee.full_name)]

--- a/hotel/static/angular-apps/hotel/room_form.html
+++ b/hotel/static/angular-apps/hotel/room_form.html
@@ -11,8 +11,12 @@
     </td>
 </tr>
 <tr>
-    <td>Special Notes</td>
-    <td> <input type="text" ng-model="room.notes" maxlength="255" /> </td>
+    <td valign="top">Admin Notes</td>
+    <td> <textarea ng-model="room.notes" rows="3" cols="80"></textarea> </td>
+</tr>
+<tr>
+    <td valign="top">Message For Staffers in Room</td>
+    <td> <textarea ng-model="room.message" rows="3" cols="80"></textarea> </td>
 </tr>
 <tr>
     <td></td>

--- a/hotel/templates/emails/room_assignment.txt
+++ b/hotel/templates/emails/room_assignment.txt
@@ -15,6 +15,8 @@ If you are assigned to receive a room on a night before {{ c.CORE_NIGHT_NAMES|fi
 
 We make every attempt to room staffers with those people that they requested.  We do our best to assign everyone to a room with at least one requested person, but this may not possible for everyone, and we may add staff to rooms that had an open slot.
 
-If there are any issues with your room at event, please come to Fest Ops and let someone in Staffing Ops know.  They will relay the information to the hotel liaison team as soon as possible.  We appreciate your hard work and we hope that you enjoy {{ c.EVENT_NAME }}.
+{% if room.message %}{{ room.message }}
+
+{% endif %}If there are any issues with your room at event, please come to Fest Ops and let someone in Staffing Ops know.  They will relay the information to the hotel liaison team as soon as possible.  We appreciate your hard work and we hope that you enjoy {{ c.EVENT_NAME }}.
 
 {{ c.STOPS_EMAIL_SIGNATURE }}


### PR DESCRIPTION
An admin can fill out a new field on the Create Room (or Edit Room) form which will be added to the automated email for that room once the room is locked in.

This requires a database change which I've already done manually on the staging and production servers after testing it locally on my own box:

``` sql
ALTER TABLE room ADD COLUMN message TEXT NOT NULL DEFAULT '';
```
