### PR TITLE
rooms sorted by locked-in status

### DIFF
--- a/hotel/site_sections/hotel_assignments.py
+++ b/hotel/site_sections/hotel_assignments.py
@@ -214,7 +214,7 @@ def _get_unassigned(session, assigned_ids):
 
 
 def _hotel_dump(session):
-    rooms = [_room_dict(room) for room in session.query(Room).order_by(Room.created).all()]
+    rooms = [_room_dict(room) for room in session.query(Room).order_by(Room.locked_in.desc(), Room.created).all()]
     assigned = sum([r['attendees'] for r in rooms], [])
     assigned_ids = [a['id'] for a in assigned]
     unassigned = _get_unassigned(session, assigned_ids)

--- a/hotel/static/angular-apps/hotel/schedule.html
+++ b/hotel/static/angular-apps/hotel/schedule.html
@@ -4,8 +4,10 @@
 
 <h3> Rooms </h3>
 
+<input type="checkbox" ng-model="showLockedIn" /> Show Locked In Rooms
+
 <table style="width:auto">
-<tr ng-repeat="room in lists.rooms"><td style="border:1px solid black" ng-class="{'locked-in': room.locked_in}">
+<tr ng-repeat="room in lists.rooms"><td style="border:1px solid black" ng-if="showLockedIn || !room.locked_in" ng-class="{'locked-in': room.locked_in}">
     <b>{{ room.nights }}</b> &nbsp;
     <a href="#/edit-room/{{ room.id }}">Edit</a> &nbsp;
     <button ng-click="deleteRoom(room.id)">Delete</button>


### PR DESCRIPTION
This implements two features:
- locked-in rooms are displayed before non-locked-in rooms
- locked-in rooms are not displayed by default, with a checkbox to show them
