### PR TITLE
3 second peformance improvement

### DIFF
--- a/hotel/__init__.py
+++ b/hotel/__init__.py
@@ -1,3 +1,5 @@
+from sqlalchemy.orm import subqueryload
+
 from uber.common import *
 from hotel._version import __version__
 from hotel.config import *

--- a/hotel/site_sections/hotel_assignments.py
+++ b/hotel/site_sections/hotel_assignments.py
@@ -259,7 +259,7 @@ def _get_unassigned(session, assigned_ids):
 
 
 def _hotel_dump(session):
-    rooms = [_room_dict(room) for room in session.query(Room).order_by(Room.locked_in.desc(), Room.created).all()]
+    rooms = [_room_dict(room) for room in session.query(Room).options(subqueryload(Room.assignments).subqueryload(RoomAssignment.attendee).subqueryload(Attendee.hotel_requests)).order_by(Room.locked_in.desc(), Room.created).all()]
     assigned = sum([r['attendees'] for r in rooms], [])
     assigned_ids = [a['id'] for a in assigned]
     unassigned = _get_unassigned(session, assigned_ids)


### PR DESCRIPTION
There was a single line of code where we were doing a ton of nested queries, so we just had to pass the option to not do that.  This does NOT fix performance on the hotel assignments page, it merely gives an easy ~3 second improvement.
