### PR TITLE
Use epoch for emails when appropriate

### DIFF
--- a/hotel/automated_emails.py
+++ b/hotel/automated_emails.py
@@ -16,10 +16,10 @@ AutomatedEmail(Attendee, 'Last chance to sign up for {EVENT_NAME} hotel room spa
            lambda a: days_before(2, c.ROOM_DEADLINE) and a.hotel_eligible and not a.hotel_requests, sender=c.ROOM_EMAIL_SENDER)
 
 AutomatedEmail(Attendee, 'Reminder to meet your {EVENT_NAME} hotel room requirements', 'hotel_hours.txt',
-           lambda a: days_before(14, c.UBER_TAKEDOWN, 7) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender=c.ROOM_EMAIL_SENDER)
+           lambda a: days_before(14, min(c.UBER_TAKEDOWN, c.EPOCH), 7) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender=c.ROOM_EMAIL_SENDER)
 
 AutomatedEmail(Attendee, 'Final reminder to meet your {EVENT_NAME} hotel room requirements', 'hotel_hours.txt',
-           lambda a: days_before(7, c.UBER_TAKEDOWN) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender=c.ROOM_EMAIL_SENDER)
+           lambda a: days_before(7, min(c.UBER_TAKEDOWN, c.EPOCH)) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender=c.ROOM_EMAIL_SENDER)
 
 AutomatedEmail(Room, '{EVENT_NAME} Hotel Room Assignment', 'room_assignment.txt', lambda r: r.locked_in,
                sender=c.ROOM_EMAIL_SENDER)

--- a/hotel/automated_emails.py
+++ b/hotel/automated_emails.py
@@ -16,10 +16,10 @@ AutomatedEmail(Attendee, 'Last chance to sign up for {EVENT_NAME} hotel room spa
            lambda a: days_before(2, c.ROOM_DEADLINE) and a.hotel_eligible and not a.hotel_requests, sender=c.ROOM_EMAIL_SENDER)
 
 AutomatedEmail(Attendee, 'Reminder to meet your {EVENT_NAME} hotel room requirements', 'hotel_hours.txt',
-           lambda a: days_before(14, min(c.UBER_TAKEDOWN, c.EPOCH), 7) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender=c.ROOM_EMAIL_SENDER)
+           lambda a: days_before(14, c.DEFAULT_EMAIL_DEADLINE, 7) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender=c.ROOM_EMAIL_SENDER)
 
 AutomatedEmail(Attendee, 'Final reminder to meet your {EVENT_NAME} hotel room requirements', 'hotel_hours.txt',
-           lambda a: days_before(7, min(c.UBER_TAKEDOWN, c.EPOCH)) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender=c.ROOM_EMAIL_SENDER)
+           lambda a: days_before(7, c.DEFAULT_EMAIL_DEADLINE) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender=c.ROOM_EMAIL_SENDER)
 
 AutomatedEmail(Room, '{EVENT_NAME} Hotel Room Assignment', 'room_assignment.txt', lambda r: r.locked_in,
                sender=c.ROOM_EMAIL_SENDER)

--- a/hotel/automated_emails.py
+++ b/hotel/automated_emails.py
@@ -16,10 +16,10 @@ AutomatedEmail(Attendee, 'Last chance to sign up for {EVENT_NAME} hotel room spa
            lambda a: days_before(2, c.ROOM_DEADLINE) and a.hotel_eligible and not a.hotel_requests, sender=c.ROOM_EMAIL_SENDER)
 
 AutomatedEmail(Attendee, 'Reminder to meet your {EVENT_NAME} hotel room requirements', 'hotel_hours.txt',
-           lambda a: days_before(14, c.DEFAULT_EMAIL_DEADLINE, 7) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender=c.ROOM_EMAIL_SENDER)
+           lambda a: days_before(14, c.FINAL_EMAIL_DEADLINE, 7) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender=c.ROOM_EMAIL_SENDER)
 
 AutomatedEmail(Attendee, 'Final reminder to meet your {EVENT_NAME} hotel room requirements', 'hotel_hours.txt',
-           lambda a: days_before(7, c.DEFAULT_EMAIL_DEADLINE) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender=c.ROOM_EMAIL_SENDER)
+           lambda a: days_before(7, c.FINAL_EMAIL_DEADLINE) and a.hotel_shifts_required and a.weighted_hours < c.HOTEL_REQ_HOURS, sender=c.ROOM_EMAIL_SENDER)
 
 AutomatedEmail(Room, '{EVENT_NAME} Hotel Room Assignment', 'room_assignment.txt', lambda r: r.locked_in,
                sender=c.ROOM_EMAIL_SENDER)

--- a/hotel/config.py
+++ b/hotel/config.py
@@ -29,6 +29,6 @@ for _attr in ['CORE_NIGHT', 'SETUP_NIGHT', 'TEARDOWN_NIGHT']:
 @Config.mixin
 class ExtraConfig:
     @property
-    def ONE_WEEK_OR_TAKEDOWN(self):
+    def ONE_WEEK_OR_TAKEDOWN_OR_EPOCH(self):
         week_from_now = c.EVENT_TIMEZONE.localize(datetime.combine(date.today() + timedelta(days=7), time(23, 59)))
-        return min(week_from_now, c.UBER_TAKEDOWN)
+        return min(week_from_now, c.UBER_TAKEDOWN, c.EPOCH)

--- a/hotel/templates/emails/room_assignment.txt
+++ b/hotel/templates/emails/room_assignment.txt
@@ -1,6 +1,6 @@
 {{ room.first_names|join_and }},
 
-This email is to confirm your upcoming {{ c.EVENT_NAME }} hotel staff room assignments.  Your roommates are listed below, so please take a moment to look over the information.  We will assume that all rooms are ok if you don’t reply to this email by {{ c.ONE_WEEK_OR_TAKEDOWN|datetime }}.
+This email is to confirm your upcoming {{ c.EVENT_NAME }} hotel staff room assignments.  Your roommates are listed below, so please take a moment to look over the information.  We will assume that all rooms are ok if you don’t reply to this email by {{ c.ONE_WEEK_OR_TAKEDOWN_OR_EPOCH|datetime }}.
 
 You can check in at the hotel front desk starting at {{ c.CHECK_IN_TIME }} on {{ room.check_in_date|date:"l, M j" }}.
 PLEASE - Make sure this is the first thing you do when you get onsite. If you have problems, come to {{ c.EVENT_NAME }} Operations Department to get it resolved.


### PR DESCRIPTION
The usage of uber_takedown has changed now that we often don't take down the system. This keeps emails from getting sent too late even if we decide to set uber_takedown to be after the start of the event (which is more accurate to reality).
