### PR TITLE
optimize: move angular dynamically genereated javascript out of static_views

### DIFF
--- a/hotel/templates/hotel_assignments/index.html
+++ b/hotel/templates/hotel_assignments/index.html
@@ -4,7 +4,7 @@
     <title>Hotel Rooms</title>
     <link rel="stylesheet" type="text/css" href="../static/styles/styles.css" />
     <script src="../static/deps/combined.js"></script>
-    <script src="../static_views/magfest.js"></script>
+    <script src="../angular/magfest.js"></script>
     <script src="../static/angular-apps/hotel/app.js"></script>
     <script type="text/javascript">
         var ROOM_DUMP = {{ dump|jsonize }};  // the Hotel service checks for a global variable with this name to preload the data


### PR DESCRIPTION
- this is to make it so we can more aggressively cache static_views
- magfest.js is the only potentially dynamic file that likely we shouldn't cache

merge after https://github.com/magfest/ubersystem/issues/1973
