### PR TITLE
override review-notes page to allow force marking a staffer as hotel room eligible

### DIFF
--- a/hotel/site_sections/hotel.py
+++ b/hotel/site_sections/hotel.py
@@ -17,6 +17,17 @@ class Root:
                                 .order_by(Attendee.full_name).all()
         }
 
+    def mark_hotel_eligible(self, session, id):
+        """
+        Force mark a non-staffer as eligible for hotel space.
+        This is outside the normal workflow, used for when we have a staffer that only has an attendee badge for
+        some reason, and we want to mark them as being OK to crash in a room.
+        """
+        attendee = session.attendee(id)
+        attendee.hotel_eligible = True
+        session.commit()
+        return '{} has now been overridden as being hotel eligible'.format(attendee.full_name)
+
     def requests(self, session, department=None):
         dept_filter = []
         requests = (session.query(HotelRequests)

--- a/hotel/templates/registration/review.html
+++ b/hotel/templates/registration/review.html
@@ -1,0 +1,9 @@
+{% extends "registration/review-base.html" %}
+
+{# This is kind of a hack, it defines a way that admins can force marking someone as hotel eligible. #}
+{# When we switch from Django to Jinja2, this can be injected into the main registration form #}
+{% block extra %}
+    {% if 'Hotel Eligibility' in attendee.for_review and c.HAS_STAFF_ROOMS_ACCESS %}
+        ++++++ <a href="../hotel/mark_hotel_eligible?id={{ attendee.id }}">Admin: Force mark as hotel eligible</a>
+    {% endif %}
+{% endblock extra %}


### PR DESCRIPTION
- Brent really needs this, this is a hacky way to add it in quickly
- Ideally, we would display the hotel eligible checkbox to admins on the reg page, but, we can't do that due to the way our templating system is setup (needs the Jinja2 pull request)