### PR TITLE
Updates Room checkout time

### DIFF
--- a/hotel/configspec.ini
+++ b/hotel/configspec.ini
@@ -14,7 +14,7 @@ night_display_order = string_list(default=list("tuesday", "wednesday", "thursday
 check_in_time = string(default='4pm')
 
 # What time in the morning people need to check out of their hotel rooms.
-check_out_time = string(default='11am')
+check_out_time = string(default='12pm/Noon')
 
 # How many hours are required before a volunteer is eligible for hotel space.
 # This often will be different based on the length of the event.


### PR DESCRIPTION
I'm not sure if this is overridden in the Event Config, I couldn't find the variable there, this change will work for MAGFest 2017.
(Noon) time is confirmed via Hotel Liaison.