### PR TITLE
remove check_shutdown() check from hotel requests page

### DIFF
--- a/hotel/site_sections/hotel_requests.py
+++ b/hotel/site_sections/hotel_requests.py
@@ -3,7 +3,6 @@ from hotel import *
 
 @all_renderable(c.SIGNUPS)
 class Root:
-    @check_shutdown
     def index(self, session, message='', decline=None, **params):
         if c.AFTER_ROOM_DEADLINE and c.STAFF_ROOMS not in AdminAccount.access_set():
             raise HTTPRedirect('../signups/index?message={}', 'The room deadline has passed')


### PR DESCRIPTION
brent requested ability for this to work on-site, and also @check_shutdown has a bug that prevents it from working in plugins right now (infinitely redirects)