### PR TITLE
Don't refer to staff food if there is no staff suite

### DIFF
--- a/hotel/models.py
+++ b/hotel/models.py
@@ -70,7 +70,7 @@ class Attendee:
 
     @property
     def shift_prereqs_complete(self):
-        return not self.placeholder and self.food_restrictions and self.shirt_size_marked \
+        return not self.placeholder and self.food_restrictions_filled_out and self.shirt_size_marked \
             and (not self.hotel_eligible or self.hotel_requests or not c.BEFORE_ROOM_DEADLINE)
 
     @property

--- a/hotel/templates/hotel_requests/hotel_item.html
+++ b/hotel/templates/hotel_requests/hotel_item.html
@@ -15,7 +15,7 @@
     {% if c.BEFORE_ROOM_DEADLINE %}
         <li>
             {{ macros.checklist_image(attendee.hotel_requests) }}
-            {% if not attendee.placeholder and attendee.food_restrictions and attendee.shirt_size_marked and not attendee.hotel_requests %}
+            {% if not attendee.placeholder and attendee.food_restrictions_filled_out and attendee.shirt_size_marked and not attendee.hotel_requests %}
                 <a href="../hotel_requests">Tell us</a>
             {% else %}
                 Tell us

--- a/hotel/templates/static_views/stafferComps.html
+++ b/hotel/templates/static_views/stafferComps.html
@@ -9,7 +9,7 @@
 The more hours you work, the more you get (don't forget about <a href="weightDesc.html">weighted hours</a>):
 <ul>
     <li> Working at least 6 hours gets you a {{ c.EVENT_NAME }} t-shirt. <br/><br/> </li>
-    <li> Working at least 12 hours gets you food in addition to the shirt.  We have professional chefs preparing 3 meals per day throughout the event. <br/><br/> </li>
+    {% if c.STAFF_GET_FOOD %}<li> Working at least 12 hours gets you food in addition to the shirt.  We have professional chefs preparing 3 meals per day throughout the event. <br/><br/> </li>{% endif %}
     <li> Working at least 18 hours gets you a complementary Staff badge for next year's {{ c.EVENT_NAME }}, which will make you eligible for space in one of our staff hotel rooms. <br/><br/> </li>
     <li> Working at least 24 hours gets you a refund on your badge for this year. <br/><br/> </li>
     <li> Working at least {{ c.HOTEL_REQ_HOURS }} hours <b>ONLY IF</b> you're a returning Staffer gets you space in one of our staff hotel rooms. <br/><br/> </li>


### PR DESCRIPTION
Adds a new STAFF_GETS_FOOD option that checks if there is a department named staff_suite -- if not, we count food restrictions as 'filled out' for the purposes of showing volunteer checklist steps, and we remove references to free food elsewhere. Part of the fix for https://github.com/magfest/magclassic/issues/64.