### PR TITLE
Remove base-admin.html

### DIFF
--- a/hotel/templates/hotel/hours.html
+++ b/hotel/templates/hotel/hours.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Unfilled Hotel Requirements{% endblock %}
 {% block content %}
 

--- a/hotel/templates/hotel/index.html
+++ b/hotel/templates/hotel/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Hotel Eligible Staffers{% endblock %}}
 {% block content %}
 

--- a/hotel/templates/hotel/no_shows.html
+++ b/hotel/templates/hotel/no_shows.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}No Show Staffers{% endblock %}
 {% block content %}
 

--- a/hotel/templates/hotel/requests.html
+++ b/hotel/templates/hotel/requests.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Hotel Requests{% endblock %}}
 {% block content %}
 

--- a/hotel/templates/hotel_requests/index.html
+++ b/hotel/templates/hotel_requests/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Hotel Requests{% endblock %}
 {% block backlink %}{% endblock %}
 {% block content %}

--- a/hotel/templates/hotel_summary/setup_teardown.html
+++ b/hotel/templates/hotel_summary/setup_teardown.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Setup/Teardown Shifts{% endblock %}
 {% block content %}
 


### PR DESCRIPTION
Now that we have Jinja2 templating, we can use the variable admin_area to control what gets included in child templates, rather than inheriting from a different template. We're implementing that now.