### PR TITLE
Convert to using a MultiChoice column for ribbons

### DIFF
--- a/hotel/models.py
+++ b/hotel/models.py
@@ -56,7 +56,7 @@ class Attendee:
 
     @property
     def hotel_shifts_required(self):
-        return bool(c.SHIFTS_CREATED and self.hotel_nights and self.ribbon != c.DEPT_HEAD_RIBBON and self.takes_shifts)
+        return bool(c.SHIFTS_CREATED and self.hotel_nights and c.DEPT_HEAD_RIBBON not in self.ribbon_ints and self.takes_shifts)
 
     @property
     def setup_hotel_approved(self):

--- a/hotel/templates/emails/hotel_reminder.txt
+++ b/hotel/templates/emails/hotel_reminder.txt
@@ -12,4 +12,4 @@ Please let us know if you have any questions.
 
 {{ c.STOPS_EMAIL_SIGNATURE }}
 
-{% if attendee.ribbon == c.DEPT_HEAD_RIBBON %}PS: Even though you're a department head, you still need to fill out the hotel form so that we know whether you want hotel room space, and you'll keep receiving these automated emails until you do!{% endif %}
+{% if c.DEPT_HEAD_RIBBON in attendee.ribbon_ints %}PS: Even though you're a department head, you still need to fill out the hotel form so that we know whether you want hotel room space, and you'll keep receiving these automated emails until you do!{% endif %}

--- a/hotel/templates/emails/hotel_rooms.txt
+++ b/hotel/templates/emails/hotel_rooms.txt
@@ -12,4 +12,4 @@ Please let us know if you have any questions.
 
 {{ c.STOPS_EMAIL_SIGNATURE }}
 
-{% if attendee.ribbon == c.DEPT_HEAD_RIBBON and not attendee.hotel_requests %}PS: Even though you're a department head, you still need to fill out the hotel form so that we know whether you want hotel room space, and you'll keep receiving these automated emails until you do!{% endif %}
+{% if c.DEPT_HEAD_RIBBON in attendee.ribbon_ints and not attendee.hotel_requests %}PS: Even though you're a department head, you still need to fill out the hotel form so that we know whether you want hotel room space, and you'll keep receiving these automated emails until you do!{% endif %}


### PR DESCRIPTION
Must be merged after https://github.com/magfest/ubersystem/pull/2711. Converts this plugin to using the syntax needed for the new MultiChoice ribbons.