### PR TITLE
Use legal name in hotel exports

### DIFF
--- a/hotel/models.py
+++ b/hotel/models.py
@@ -92,6 +92,32 @@ class Attendee:
         else:
             return 'Hotel nights: ' + hr.nights_display
 
+    @property
+    def legal_first_name(self):
+        """
+        Hotel exports need split legal names, but we don't collect split legal names, so we're going to have to guess.
+
+        Returns one of the following:
+            The first part of the legal name before a space, if the legal name has multiple parts
+            The legal name itself, if the legal name is one word -- this is because attendees are more likely to use a
+                different first name than their legal name, so might just enter, e.g., "Victoria" for their legal name
+            The first name, if there is no legal name
+        """
+        if self.legal_name:
+            return self.legal_name.split(' ', 1)[0] if ' ' in self.legal_name else self.legal_name
+        return self.first_name
+
+    @property
+    def legal_last_name(self):
+        """
+        Hotel exports need split legal names, but we don't collect split legal names, so we're going to have to guess.
+
+        Returns one of the following:
+            The second part of the legal name after a space, if the legal name has multiple parts
+            The last name, if there is no legal name or if the legal name is just one word
+        """
+        return self.legal_name.split(' ', 1)[1] if self.legal_name and ' ' in self.legal_name else self.last_name
+
 
 class HotelRequests(MagModel, NightsMixin):
     attendee_id        = Column(UUID, ForeignKey('attendee.id'), unique=True)

--- a/hotel/site_sections/hotel_assignments.py
+++ b/hotel/site_sections/hotel_assignments.py
@@ -155,10 +155,10 @@ class Root:
         for room in session.query(Room).order_by(Room.created).all():
             if room.assignments:
                 assignments = [ra.attendee for ra in room.assignments[:4]]
-                roommates = [[a.last_name, a.first_name] for a in assignments[1:]] + [['', '']] * (4 - len(assignments))
+                roommates = [[a.legal_name.split(' ', 1)[1], a.legal_name.split(' ', 1)[0]] for a in assignments[1:]] + [['', '']] * (4 - len(assignments))
                 out.writerow([
-                    assignments[0].last_name,
-                    assignments[0].first_name,
+                    assignments[0].legal_name.split(' ', 1)[1],
+                    assignments[0].legal_name.split(' ', 1)[0],
                     room.check_in_date.strftime('%Y-%m-%d'),
                     room.check_out_date.strftime('%Y-%m-%d'),
                     'Q2',  # code for two beds, 'K1' would indicate a single king-sized bed
@@ -203,8 +203,8 @@ class Root:
                 for i, attendee in enumerate([ra.attendee for ra in room.assignments[:4]]):
                     prefix = 'Guest{}'.format(i + 1)
                     row.update({
-                        prefix + 'FirstName': attendee.first_name,
-                        prefix + 'LastName': attendee.last_name
+                        prefix + 'FirstName': attendee.legal_name.split(' ', 1)[0],
+                        prefix + 'LastName': attendee.legal_name.split(' ', 1)[1]
                     })
                 out.writerow(list(row.values()))
 

--- a/hotel/site_sections/hotel_assignments.py
+++ b/hotel/site_sections/hotel_assignments.py
@@ -155,10 +155,10 @@ class Root:
         for room in session.query(Room).order_by(Room.created).all():
             if room.assignments:
                 assignments = [ra.attendee for ra in room.assignments[:4]]
-                roommates = [[a.legal_name.split(' ', 1)[1], a.legal_name.split(' ', 1)[0]] for a in assignments[1:]] + [['', '']] * (4 - len(assignments))
+                roommates = [[a.legal_last_name, a.legal_first_name] for a in assignments[1:]] + [['', '']] * (4 - len(assignments))
                 out.writerow([
-                    assignments[0].legal_name.split(' ', 1)[1],
-                    assignments[0].legal_name.split(' ', 1)[0],
+                    assignments[0].legal_last_name,
+                    assignments[0].legal_first_name,
                     room.check_in_date.strftime('%Y-%m-%d'),
                     room.check_out_date.strftime('%Y-%m-%d'),
                     'Q2',  # code for two beds, 'K1' would indicate a single king-sized bed
@@ -203,8 +203,8 @@ class Root:
                 for i, attendee in enumerate([ra.attendee for ra in room.assignments[:4]]):
                     prefix = 'Guest{}'.format(i + 1)
                     row.update({
-                        prefix + 'FirstName': attendee.legal_name.split(' ', 1)[0],
-                        prefix + 'LastName': attendee.legal_name.split(' ', 1)[1]
+                        prefix + 'FirstName': attendee.legal_first_name,
+                        prefix + 'LastName': attendee.legal_last_name
                     })
                 out.writerow(list(row.values()))
 


### PR DESCRIPTION
Fixes magfest/ubersystem#2727. Unfortunately, because we collect the legal_name as one block, we have to clumsily guess at what the first and last name is.