### PR TITLE
Fixes magfest/ubersystem#2970: Hides roommate requests/anti-requests & special needs from non-STOPS admins

### DIFF
--- a/hotel/site_sections/hotel.py
+++ b/hotel/site_sections/hotel.py
@@ -49,7 +49,9 @@ class Root:
                 *dept_filter) \
             .order_by(Attendee.full_name).all()
 
+        admin_has_room_access = bool(set([c.ADMIN, c.STAFF_ROOMS]).intersection(session.current_admin_account().access_ints))
         return {
+            'admin_has_room_access': admin_has_room_access,
             'requests': requests,
             'department_id': department_id,
             'department_name': c.DEPARTMENTS.get(department_id, 'All'),

--- a/hotel/templates/hotel/requests.html
+++ b/hotel/templates/hotel/requests.html
@@ -55,19 +55,24 @@
 <tr class="header">
     <td>Staffer Name</td>
     <td>Departments</td>
-    <td>Roommate Requests</td>
-    <td>Roommate Anti-requests</td>
-    <td>Special Needs</td>
+    {% if admin_has_room_access %}
+      <td>Roommate Requests</td>
+      <td>Roommate Anti-requests</td>
+      <td>Special Needs</td>
+    {% endif %}
     <td>Requested Nights</td>
     <td>Extra Nights</td>
 </tr>
+
 {% for request in requests %}
     <tr bgcolor="{{ loop.cycle('#FFFFFF','#DDDDDD') }}">
         <td><a href="../registration/form?id={{ request.attendee.id }}">{{ request.attendee.full_name }}</a></td>
         <td>{{ request.attendee.assigned_depts_labels|join(" / ") }}</td>
-        <td>{{ request.wanted_roommates|linebreaksbr }}</td>
-        <td>{{ request.unwanted_roommates|linebreaksbr }}</td>
-        <td>{{ request.special_needs }}</td>
+        {% if admin_has_room_access %}
+          <td>{{ request.wanted_roommates|linebreaksbr }}</td>
+          <td>{{ request.unwanted_roommates|linebreaksbr }}</td>
+          <td>{{ request.special_needs }}</td>
+        {% endif %}
         <td class="nights">{{ request.attendee.hotel_requests.nights_display }}</td>
         <td>
             {% if not request.setup_teardown %}


### PR DESCRIPTION
This does not cut off access to the whole page, because dept heads need access for the dept checklist. It does hide the columns with sensitive info (roommate requests/anti-requests & special needs).