### PR TITLE
OFFICE-1304: swapped shirt_size_marked for the newer shirt_info_marked

### DIFF
--- a/hotel/models.py
+++ b/hotel/models.py
@@ -192,7 +192,7 @@ class Attendee:
 
     @property
     def shift_prereqs_complete(self):
-        return not self.placeholder and self.food_restrictions_filled_out and self.shirt_size_marked \
+        return not self.placeholder and self.food_restrictions_filled_out and self.shirt_info_marked \
             and (not self.hotel_eligible or self.hotel_requests or not c.BEFORE_ROOM_DEADLINE)
 
     @property

--- a/hotel/templates/hotel_requests/hotel_item.html
+++ b/hotel/templates/hotel_requests/hotel_item.html
@@ -15,7 +15,7 @@
     {% if c.BEFORE_ROOM_DEADLINE %}
         <li>
             {{ macros.checklist_image(attendee.hotel_requests) }}
-            {% if not attendee.placeholder and attendee.food_restrictions_filled_out and attendee.shirt_size_marked and not attendee.hotel_requests %}
+            {% if not attendee.placeholder and attendee.food_restrictions_filled_out and attendee.shirt_info_marked and not attendee.hotel_requests %}
                 <a href="../hotel_requests">Tell us</a>
             {% else %}
                 Tell us


### PR DESCRIPTION
NOTE: Nick is encouraging paid MAGFolks to take Thanksgiving weekend off. I'm on vacation having fun getting caught up on some programming work, but others are encouraged to take it easy and pick this up on Monday. This needs to get deployed by COB Monday, but it's okay to wait until then.

This goes along with https://github.com/magfest/ubersystem/pull/2973 and updates the hotel step to use the new ``shirt_info_marked`` property instead of ``shirt_size_marked``.

Strictly speaking this isn't necessary, but it's more correct to use the newer property, since otherwise the next step could become available before the previous step, and we prefer to force volunteers to complete the steps in order.